### PR TITLE
Fix compile errors for macOS (ambiguous call to dump())

### DIFF
--- a/bench/cpp/testb.h
+++ b/bench/cpp/testb.h
@@ -93,16 +93,16 @@ public:
 		// logic depends.  This forces that logic to be recalculated
 		// before the top of the clock.
 		eval();
-		if (m_trace) m_trace->dump((uint64_t)(10*m_tickcount-2));
+		if (m_trace) m_trace->dump((vluint64_t)(10*m_tickcount-2));
 		m_core->i_clk = 1;
 		m_core->i_pixclk = 1;
 		eval();
-		if (m_trace) m_trace->dump((uint64_t)(10*m_tickcount));
+		if (m_trace) m_trace->dump((vluint64_t)(10*m_tickcount));
 		m_core->i_clk = 0;
 		m_core->i_pixclk = 0;
 		eval();
 		if (m_trace) {
-			m_trace->dump((uint64_t)(10*m_tickcount+5));
+			m_trace->dump((vluint64_t)(10*m_tickcount+5));
 			m_trace->flush();
 		}
 	}


### PR DESCRIPTION
same as here: https://github.com/ZipCPU/dblclockfft/commit/b99cf60c0d35ebabe2a3753fe9f87c3987e4de60