### PR TITLE
Fixed VERILATOR_ROOT variable extraction

### DIFF
--- a/bench/cpp/Makefile
+++ b/bench/cpp/Makefile
@@ -70,7 +70,7 @@ VOBJDR	:= $(RTLD)/obj_dir
 ifneq ($(VERILATOR_ROOT),)
 VERILATOR:=$(VERILATOR_ROOT)/bin/verilator
 else
-VERILATOR_ROOT ?= $(shell bash -c 'verilator -V|grep VERILATOR_ROOT | head -1 | sed -e " s/^.*=\s*//"')
+VERILATOR_ROOT ?= $(shell bash -c 'verilator --getenv VERILATOR_ROOT')
 endif
 export	$(VERILATOR)
 VROOT	:= $(VERILATOR_ROOT)


### PR DESCRIPTION
If the installed version of Verilator was built in a different environment, the existing command will extract the wrong `VERILATOR_ROOT` path. For example, when using the [oss-cad-suite-build](https://github.com/YosysHQ/oss-cad-suite-build), `verilator -V` returns the following:

```
Verilator 5.027 devel rev v5.026-136-g48c71ef76

Copyright 2003-2024 by Wilson Snyder.  Verilator is free software; you can
redistribute it and/or modify the Verilator internals under the terms of
either the GNU Lesser General Public License Version 3 or the Perl Artistic
License Version 2.0.

See https://verilator.org for documentation

Summary of configuration:
  Compiled in defaults if not in environment:
    SYSTEMC            = 
    SYSTEMC_ARCH       = 
    SYSTEMC_INCLUDE    = 
    SYSTEMC_LIBDIR     = 
    VERILATOR_ROOT     = /yosyshq/share/verilator
    SystemC system-wide = 0

Environment:
    MAKE               = 
    PERL               = 
    PYTHON3            = 
    SYSTEMC            = 
    SYSTEMC_ARCH       = 
    SYSTEMC_INCLUDE    = 
    SYSTEMC_LIBDIR     = 
    VERILATOR_BIN      = 
    VERILATOR_ROOT     = /opt/oss-cad-suite/share/verilator

Supported features (compiled-in or forced by environment):
    COROUTINES         = 1
    SYSTEMC            = 
```

The existing command returns `/yosyshq/share/verilator`, the path used when built by YosysHQ, rather than `/opt/oss-cad-suite/share/verilator`, the path Verilator was installed to on the current system. Using the `--getenv` flag instead correctly returns the second path.